### PR TITLE
Differ's merge_text's body result now is a single string instead of an...

### DIFF
--- a/lib/dyph3/differ.rb
+++ b/lib/dyph3/differ.rb
@@ -8,7 +8,8 @@ module Dyph3
         base: "|||||||",
         right: "=======",
         close: ">>>>>>>"
-      }
+      },
+      include_base: true
     }
     
     def self.diff3_text(yourtext, original, theirtext, options={})
@@ -16,7 +17,11 @@ module Dyph3
     end
     
     def self.merge_text(yourtext, original, theirtext, options={})
-      merge(yourtext.split("\n"), original.split("\n"), theirtext.split("\n"), options)
+      result = merge(yourtext.split("\n"), original.split("\n"), theirtext.split("\n"), options)
+      
+      result[:body] = result[:body].join("\n")
+      
+      result
     end
     
     
@@ -262,9 +267,11 @@ module Dyph3
           (r3[1] .. r3[2]).each do |lineno|
             res[:body] << text3[0][lineno - 1]
           end
-          res[:body] << options[:markers][:base]
-          (r3[5] .. r3[6]).each do |lineno|
-            res[:body] << text3[2][lineno - 1]
+          if options[:include_base]
+            res[:body] << options[:markers][:base]
+            (r3[5] .. r3[6]).each do |lineno|
+              res[:body] << text3[2][lineno - 1]
+            end
           end
           res[:body] << options[:markers][:right]
           (r3[3] .. r3[4]).each do |lineno|

--- a/spec/lib/dyph3/differ_spec.rb
+++ b/spec/lib/dyph3/differ_spec.rb
@@ -61,28 +61,43 @@ TEXT
   r.strip
 }
 
-  it "should be tested" do
-    result = Dyph3::Differ.merge_text(left, base, right, markers: {left: "<<<<<<< start", base: "|||||||", right: "=======", close: ">>>>>>> changed_b"})
-    expect(result[:conflict]).to eq(1)
-    expect(result[:body].join("\n")).to eq expected_result
-    
-  end
-
   it "should not explode" do
     result = Dyph3::Differ.merge_text(left, base, right, markers: {left: "<<<<<<< start", base: "|||||||", right: "=======", close: ">>>>>>> changed_b"})
     expect(result[:conflict]).to eq(1)
-    expect(result[:body].join("\n")).to eq expected_result
+    expect(result[:body]).to eq expected_result
   end
 
   it "should not be conflicted when not conflicted" do
     result = Dyph3::Differ.merge_text(left, base, left, markers: {left: "<<<<<<< start", base: "|||||||", right: "=======", close: ">>>>>>> changed_b"})
-    expect(result[:body].join("\n")).to eq left.strip #BUGBUG: differ losing a new line?
+    expect(result[:body]).to eq left.strip #BUGBUG: differ losing a new line?
     expect(result[:conflict]).to eq(0)
   end
 
   it "should not be conflicted when not conflicted" do
     result = Dyph3::Differ.merge_text(base, base, base, markers: {left: "<<<<<<< start", base: "|||||||", right: "=======", close: ">>>>>>> changed_b"})
-    expect(result[:body].join("\n")).to eq base.strip #BUGBUG: differ losing a new line?
+    expect(result[:body]).to eq base.strip #BUGBUG: differ losing a new line?
     expect(result[:conflict]).to eq(0)
+  end
+  
+  it "should allow you to not include the base in the result" do
+    expected_result = <<-TEXT.strip
+This is the baseline.
+<<<<<<< start
+The start (changed by A).
+=======
+The start.
+B added this line.
+>>>>>>> changed_b
+The end.
+cats
+dogs
+pigs
+cows
+chickens
+TEXT
+    
+    result = Dyph3::Differ.merge_text(left, base, right, include_base: false, markers: {left: "<<<<<<< start", base: "|||||||", right: "=======", close: ">>>>>>> changed_b"})
+    expect(result[:conflict]).to eq(1)
+    expect(result[:body]).to eq expected_result
   end
 end


### PR DESCRIPTION
... array. Also add a 'include_base' option that, if set to false, will exclude the base in conflicts
