### PR TITLE
Extract min_diff from GoBoundless/www

### DIFF
--- a/dyph.gemspec
+++ b/dyph.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry-rescue"
   spec.add_development_dependency "pry-stack_explorer"
   spec.add_development_dependency 'rspec', '~> 3.3.0'
+  spec.add_development_dependency 'rspec-its', '~> 1.2.0'
   spec.add_development_dependency "awesome_print"
   spec.add_development_dependency "factory_girl"
   spec.add_development_dependency "codeclimate-test-reporter"

--- a/lib/dyph.rb
+++ b/lib/dyph.rb
@@ -1,6 +1,8 @@
 require "dyph/version"
 require "dyph/differ"
 
+require "dyph/min_diff"
+
 require "dyph/merge_result"
 
 require "dyph/outcome"

--- a/lib/dyph/min_diff.rb
+++ b/lib/dyph/min_diff.rb
@@ -1,0 +1,76 @@
+module Dyph
+
+  # Perform a two-way diff of the given arrays twice, the second time with left and right reversed, and return the smaller result.
+  # @param left [Object]
+  # @param base [Object]
+  # @return [MergeResult]
+  def self.min_diff(left, right)
+    a = Differ.two_way_diff(left, right)
+    b = Differ.two_way_diff(right, left)
+    if a.size <= b.size
+      a
+    else
+      sort_actions(invert_actions(b))
+    end
+  end
+
+  # Invert the meanings of deleted and added chunks.
+  # @param actions [object]
+  # @return actions [object]
+  def self.invert_actions(actions)
+    actions.map do |action|
+      case action
+      when Action::Add     then Action::Delete.new(value: action.value, old_index: action.old_index, new_index: action.new_index)
+      when Action::Delete  then Action::Add.new(value:    action.value, old_index: action.old_index, new_index: action.new_index)
+      else action
+      end
+    end
+  end
+
+  # Reorder a diff result so that deletes are always before adds.
+  # @param actions [object]
+  # @return actions [object]
+  def self.sort_actions(actions)
+    actions = actions.reduce([]) do |result, action|
+      case action
+      when Action::Delete, Action::Add
+        ChangeGroup.begin(result)
+        result.last.add action
+      when Action::NoChange
+        ChangeGroup.end(result)
+        result << action
+      end
+      result
+    end
+    ChangeGroup.end(actions)
+    return actions
+  end
+
+  class ChangeGroup
+
+    def initialize
+      @adds = []
+      @deletes = []
+    end
+
+    def add(change)
+      case change
+      when Action::Delete then @deletes << change
+      when Action::Add    then @adds    << change
+      end
+    end
+
+    def values
+      [*@deletes, *@adds]
+    end
+
+    def self.begin(action)
+      action << new unless action.last.is_a? self
+    end
+
+    def self.end(action)
+      action.concat(action.pop.values) if action.last.is_a? self
+    end
+  end
+
+end

--- a/lib/dyph/two_way_differs/output_converter.rb
+++ b/lib/dyph/two_way_differs/output_converter.rb
@@ -1,4 +1,3 @@
-# rubocop:disable Metrics/AbcSize
 module Dyph
   module TwoWayDiffers
     # rubocop:disable Metrics/ModuleLength

--- a/lib/dyph/two_way_differs/output_converter.rb
+++ b/lib/dyph/two_way_differs/output_converter.rb
@@ -1,3 +1,4 @@
+# rubocop:disable Metrics/AbcSize
 module Dyph
   module TwoWayDiffers
     # rubocop:disable Metrics/ModuleLength

--- a/spec/lib/dyph/min_diff_spec.rb
+++ b/spec/lib/dyph/min_diff_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+describe Dyph do
+  describe ".min_diff" do
+    let(:left)  { %w[a b c d e f g] }
+    let(:right) { %w[d e f g a b c] }
+    let(:regular_diff) { Dyph::Differ.two_way_diff(left, right) }
+    let(:subject) { Dyph.min_diff(left, right) }
+
+    its(:length) { is_expected.to be < regular_diff.length }
+
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,12 +1,13 @@
 require "codeclimate-test-reporter"
 CodeClimate::TestReporter.start
 
-require 'dyph'
+require "dyph"
 
 require "pry"
 require "awesome_print"
-require 'codeclimate-test-reporter'
-require 'faker'
+require "codeclimate-test-reporter"
+require "faker"
+require "rspec/its"
 
 Dir[File.dirname(__FILE__) + '/fixtures/*.rb'].each {|file| require file }
 


### PR DESCRIPTION
This was previously a monkey-patch in our main app. I've extracted it here, but I think having it all in one file may be a little unclean. `invert_actions` and `sort_actions` (with the supporting `ChangeGroup`) could live elsewhere, but I'm not sure where the existing structure would accept stuff like this.
